### PR TITLE
Fix parameter order in PQ function call within DEM method

### DIFF
--- a/rockphypy/EM.py
+++ b/rockphypy/EM.py
@@ -782,7 +782,7 @@ class EM:
         '''
         K_eff,G_eff=y  # unpack current values of y
         Gi,Ki,alpha = params # unpack parameters 
-        P, Q= EM.PQ(G_eff,K_eff,Gi,Ki, alpha)
+        P, Q= EM.PQ(K_eff, G_eff, Ki, Gi, alpha)
         derivs = [1/(1-t) * (Ki-K_eff) * P,  1/(1-t) * -G_eff * Q]
         return derivs
 


### PR DESCRIPTION
The call to PQ() from within DEM() passes effective and inclusion moduli in a wrong order, causing DEM to converge to wrong results.